### PR TITLE
Pause director systems during hard pause

### DIFF
--- a/crates/game/src/systems/director/mod.rs
+++ b/crates/game/src/systems/director/mod.rs
@@ -180,7 +180,12 @@ fn director_tick_system(
     mut runtime: ResMut<DirectorRuntime>,
     mut queue: ResMut<CommandQueue>,
     mut requests: ResMut<DirectorRequests>,
+    pause: Res<PauseState>,
 ) {
+    if pause.hard_paused_sp {
+        return;
+    }
+
     if runtime.cfg.is_none() {
         return;
     }
@@ -280,7 +285,12 @@ fn missions_system(
     mut econ: ResMut<EconIntent>,
     mut queue: ResMut<CommandQueue>,
     state: Res<DirectorState>,
+    pause: Res<PauseState>,
 ) {
+    if pause.hard_paused_sp {
+        return;
+    }
+
     if runtime.cfg.is_none() {
         return;
     }
@@ -351,7 +361,12 @@ fn spawn_system(
     state: Res<DirectorState>,
     inputs: Res<DirectorInputs>,
     mut queue: ResMut<CommandQueue>,
+    pause: Res<PauseState>,
 ) {
+    if pause.hard_paused_sp {
+        return;
+    }
+
     if runtime.spawns_emitted {
         return;
     }
@@ -387,7 +402,12 @@ fn cleanup_system(
     mut state: ResMut<DirectorState>,
     mut runtime: ResMut<DirectorRuntime>,
     mut econ: ResMut<EconIntent>,
+    pause: Res<PauseState>,
 ) {
+    if pause.hard_paused_sp {
+        return;
+    }
+
     if runtime.missions_total > 0
         && runtime.missions_resolved >= runtime.missions_total
         && !matches!(state.status, LegStatus::Completed(_))

--- a/crates/game/tests/pause_resumes.rs
+++ b/crates/game/tests/pause_resumes.rs
@@ -1,0 +1,98 @@
+use bevy::prelude::FixedUpdate;
+use game::systems::command_queue::CommandQueue;
+use game::systems::director::pause_wheel::PauseState;
+use game::systems::director::{DirectorState, LegStatus};
+use game::{build_headless_app, request_new_leg};
+
+#[test]
+fn fixed_update_respects_pause_state() {
+    let mut app = build_headless_app();
+
+    // Prime the simulation until the director starts emitting commands.
+    let mut baseline_commands = Vec::new();
+    for _ in 0..50 {
+        app.world_mut().run_schedule(FixedUpdate);
+        let drained = {
+            let mut queue = app.world_mut().resource_mut::<CommandQueue>();
+            queue.drain()
+        };
+        if !drained.is_empty() {
+            baseline_commands = drained;
+            break;
+        }
+    }
+
+    assert!(
+        !baseline_commands.is_empty(),
+        "expected the director to emit commands before pausing",
+    );
+
+    let leg_tick_before_pause = {
+        let state = app.world().resource::<DirectorState>();
+        assert!(
+            !matches!(state.status, LegStatus::Completed(_)),
+            "director should still be mid-leg before pausing",
+        );
+        state.leg_tick
+    };
+
+    {
+        let mut pause = app.world_mut().resource_mut::<PauseState>();
+        pause.hard_paused_sp = true;
+    }
+    request_new_leg(&mut app);
+
+    for _ in 0..10 {
+        app.world_mut().run_schedule(FixedUpdate);
+    }
+
+    let paused_commands = {
+        let mut queue = app.world_mut().resource_mut::<CommandQueue>();
+        queue.drain()
+    };
+    assert!(
+        paused_commands.is_empty(),
+        "no commands should be emitted while hard paused",
+    );
+
+    let (leg_tick_after_pause, status_after_pause) = {
+        let state = app.world().resource::<DirectorState>();
+        assert_eq!(
+            state.leg_tick, leg_tick_before_pause,
+            "leg tick should not advance while paused"
+        );
+        (state.leg_tick, state.status)
+    };
+
+    {
+        let mut pause = app.world_mut().resource_mut::<PauseState>();
+        pause.hard_paused_sp = false;
+    }
+
+    let mut resumed_commands = Vec::new();
+    let mut resumed_state = None;
+    for _ in 0..200 {
+        app.world_mut().run_schedule(FixedUpdate);
+        let drained = {
+            let mut queue = app.world_mut().resource_mut::<CommandQueue>();
+            queue.drain()
+        };
+        if !drained.is_empty() {
+            resumed_commands = drained;
+            let state = app.world().resource::<DirectorState>();
+            resumed_state = Some((state.leg_tick, state.status));
+            break;
+        }
+    }
+
+    let (resumed_tick, resumed_status) =
+        resumed_state.expect("director state should advance after clearing the hard pause");
+    assert!(
+        !resumed_commands.is_empty(),
+        "commands should resume after clearing the hard pause",
+    );
+    assert!(
+        resumed_tick != leg_tick_after_pause || resumed_status != status_after_pause,
+        "director should make progress once unpaused",
+    );
+}


### PR DESCRIPTION
## Summary
- inject the PauseState resource into director systems and early-return when single-player hard pause is active
- ensure FixedUpdate does not progress while paused to prevent ticks and command emission
- add regression coverage verifying commands stop during pause and resume once unpaused

## Testing
- cargo test fixed_update_respects_pause_state

------
https://chatgpt.com/codex/tasks/task_e_68ff79978c50832e8d32e5a6e85a92fa