### PR TITLE
Add deterministic Cargo profile for reproducible builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,10 @@ debug = 0
 lto = "thin"
 codegen-units = 1
 split-debuginfo = "packed"
+
+[profile.deterministic]
+inherits = "release"
+debug = 0
+lto = "thin"
+codegen-units = 1
+split-debuginfo = "packed"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Foundation for the Detterot prototype. Launch the Bevy game from VS Code (F5) to
 ## Tooling
 - `cargo fmt`, `cargo clippy -D warnings`, and `cargo test` must pass before merging.
 - `tools/repro_harness` replays golden records and validates hashes for determinism checks.
+- Build reproducible release artifacts with `cargo build --profile deterministic --features deterministic`; the workspace's
+  deterministic profile mirrors the release settings and locks codegen for bit-for-bit binaries.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for etiquette, performance expectations, and the economy invariants CI enforces.
 


### PR DESCRIPTION
## Summary
- add a deterministic Cargo profile that mirrors release settings for reproducible builds
- document the deterministic build command in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff914af97c832ebef0d2255bd676a9