### PR TITLE
Track cumulative basis overlay totals in director

### DIFF
--- a/crates/game/src/lib.rs
+++ b/crates/game/src/lib.rs
@@ -254,6 +254,7 @@ fn leg_context_from_options(options: &CliOptions) -> LegContext {
         player_rating: options.player_rating(),
         multiplayer: false,
         prior_danger_score: None,
+        basis_overlay_bp_total: 0,
     }
 }
 

--- a/crates/game/tests/integration/physics_step.rs
+++ b/crates/game/tests/integration/physics_step.rs
@@ -56,6 +56,7 @@ fn test_leg_context() -> LegContext {
         player_rating: 40,
         multiplayer: false,
         prior_danger_score: None,
+        basis_overlay_bp_total: 0,
     }
 }
 

--- a/crates/game/tests/integration/wheel_state_transitions.rs
+++ b/crates/game/tests/integration/wheel_state_transitions.rs
@@ -211,6 +211,7 @@ fn test_leg_context() -> LegContext {
         player_rating: 40,
         multiplayer: false,
         prior_danger_score: None,
+        basis_overlay_bp_total: 0,
     }
 }
 


### PR DESCRIPTION
## Summary
- store a running basis overlay total on the leg context
- accumulate pending basis overlay deltas when finalizing legs and log the total
- add a deterministic test ensuring the total basis overlay value advances across legs

## Testing
- cargo test finalize_leg_accumulates_basis_overlay_total

------
https://chatgpt.com/codex/tasks/task_e_6900309c8a04832e868704d5913531ec