### PR TITLE
Allow continue-after-mismatch flag to accept boolean values

### DIFF
--- a/crates/game/src/cli.rs
+++ b/crates/game/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Parser, ValueEnum};
+use clap::{builder::BoolishValueParser, ArgAction, Parser, ValueEnum};
 
 use crate::systems::economy::Weather;
 
@@ -65,7 +65,13 @@ pub struct CliOptions {
     pub fixed_dt: Option<f64>,
     #[arg(long)]
     pub headless: bool,
-    #[arg(long = "continue-after-mismatch", action = ArgAction::SetTrue)]
+    #[arg(
+        long = "continue-after-mismatch",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new()
+    )]
     pub continue_after_mismatch: bool,
     #[arg(long = "debug-logs")]
     pub debug_logs: bool,


### PR DESCRIPTION
## Summary
- allow the `--continue-after-mismatch` flag to take an optional boolean value so CI can pass `false`
- use Clap's BoolishValueParser to support both bare flags and explicit true/false values

## Testing
- cargo run -p game -- --mode replay --io repro/records/leg_seed_01.json --fixed-dt 0.0333333333 --headless --continue-after-mismatch false

------
https://chatgpt.com/codex/tasks/task_e_690092b7a9e8832eae04275fa8b47039