### PR TITLE
Gate Avian physics behind optional feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,14 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Clippy (deterministic feature)
         run: cargo clippy -p game --all-targets --features deterministic -- -D warnings
+      - name: Clippy (avian physics feature)
+        run: cargo clippy -p game --all-targets --features avian_physics -- -D warnings
       - name: Tests (workspace)
         run: cargo test --workspace
       - name: Tests (deterministic game)
         run: cargo test -p game --features deterministic
+      - name: Tests (avian physics game)
+        run: cargo test -p game --features avian_physics
       - name: Determinism guard
         run: ci/grep_banned_random.sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bevy = { version = "0.17.2", default-features = false, features = [
     "bevy_asset",
     "bevy_scene",
     "bevy_winit",
+    "bevy_log",
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_pbr",

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![CI](https://github.com/Vecipher/detterot/actions/workflows/ci.yml/badge.svg)
 
-Foundation for the Detterot prototype. Launch the Bevy game from VS Code (F5) to see a neon cube lit in a simple scene with diagnostics overlay, Avian 3D physics, Kira audio, and automated camera paths. Continuous integration keeps formatting, linting, tests, and determinism checks green on both macOS and Ubuntu.
+Foundation for the Detterot prototype. Launch the Bevy game from VS Code (F5) to see a neon cube lit in a simple scene with diagnostics overlay, Kira audio, and automated camera paths. Enable the optional `avian_physics` feature to swap the default grid/no-op physics loop for Avian 3D's schedule. Continuous integration keeps formatting, linting, tests, and determinism checks green on both macOS and Ubuntu.
 
 ## Getting started
 1. Install the recommended VS Code extensions (Rust Analyzer, CodeLLDB, Even Better TOML).
 2. Open the workspace and press <kbd>F5</kbd> ("Run game (debug)") to build and launch the window.
 3. Explore `repro/perf_scenes.toml` and `repro/paths/` to tweak autoplay camera paths.
-4. Run the debug config (F5) to build with `--features dev` and access Avian's collider debug overlay; release builds omit the extra debug plugin.
+4. Run the debug config (F5) to build with `--features dev` (which enables `avian_physics`) and access Avian's collider debug overlay; release builds omit the extra debug plugin and stick to the deterministic grid physics loop.
 
 ## Tooling
 - `cargo fmt`, `cargo clippy -D warnings`, and `cargo test` must pass before merging.

--- a/crates/game/Cargo.toml
+++ b/crates/game/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 
 [dependencies]
 anyhow = "1"
-avian3d = { workspace = true }
+avian3d = { workspace = true, optional = true }
 bevy = { workspace = true }
 blake3 = "1"
 clap = { version = "4.5", features = ["derive"] }
@@ -28,7 +28,8 @@ worldgen = { path = "../worldgen" }
 
 [features]
 default = []
-dev = ["avian3d/debug-plugin"]
+avian_physics = ["dep:avian3d"]
+dev = ["avian_physics", "avian3d/debug-plugin"]
 deterministic = []
 econ_logs = []
 m2_logs = []

--- a/crates/game/tests/integration/physics_step.rs
+++ b/crates/game/tests/integration/physics_step.rs
@@ -1,4 +1,3 @@
-use avian3d::prelude::{Physics, SubstepCount};
 use bevy::prelude::*;
 use bevy::time::{Fixed, Time as BevyTime};
 
@@ -7,7 +6,8 @@ const FIXED_STEP_SECONDS: f64 = f64::from_bits(0x3F91_1111_1111_1111);
 use game::scheduling;
 use game::systems::command_queue::CommandQueue;
 use game::systems::director::{
-    DirectorPlugin, DirectorState, LegContext, LegStatus, Outcome, WheelState,
+    DirectorPlugin, DirectorState, LegContext, LegStatus, Outcome, Physics, PhysicsBackend,
+    SubstepCount, WheelState,
 };
 use game::systems::economy::{Pp, RouteId, Weather};
 use repro::Command;
@@ -47,6 +47,18 @@ fn build_director_app() -> App {
     app.finish();
     app.update();
     app
+}
+
+#[test]
+fn records_physics_backend() {
+    let app = build_director_app();
+    let backend = app.world().resource::<PhysicsBackend>();
+
+    #[cfg(feature = "avian_physics")]
+    assert_eq!(*backend, PhysicsBackend::Avian);
+
+    #[cfg(not(feature = "avian_physics"))]
+    assert_eq!(*backend, PhysicsBackend::Grid);
 }
 
 fn test_leg_context() -> LegContext {


### PR DESCRIPTION
## Summary
- gate the director’s Avian schedule behind a new `avian_physics` feature and provide a stubbed grid backend when the feature is disabled
- expose the active physics backend to tests, update integration coverage, and document the optional Avian path
- enable the new feature in CI lint/test steps and ensure Bevy’s log module is available in the default feature set

## Testing
- cargo test --workspace
- cargo test -p game --features deterministic
- cargo test -p game --features avian_physics

------
https://chatgpt.com/codex/tasks/task_e_6900abc433e0832e9daca8efd98726c0