### PR TITLE
Update replay mismatch default behaviour

### DIFF
--- a/crates/game/src/cli.rs
+++ b/crates/game/src/cli.rs
@@ -70,6 +70,7 @@ pub struct CliOptions {
         action = ArgAction::Set,
         num_args = 0..=1,
         default_missing_value = "true",
+        default_value_t = true,
         value_parser = BoolishValueParser::new()
     )]
     pub continue_after_mismatch: bool,
@@ -116,7 +117,7 @@ impl CliOptions {
             io: None,
             fixed_dt: None,
             headless: false,
-            continue_after_mismatch: false,
+            continue_after_mismatch: true,
             debug_logs: false,
             world_seed: DEFAULT_WORLD_SEED,
             link_id: DEFAULT_LINK_ID,

--- a/crates/game/tests/integration/replay_golden.rs
+++ b/crates/game/tests/integration/replay_golden.rs
@@ -25,6 +25,7 @@ fn golden_records_replay_cleanly() {
         assert_eq!(hash, expected.trim(), "hash mismatch for {path}");
 
         let mut opts = CliOptions::for_mode(Mode::Replay);
+        opts.continue_after_mismatch = false;
         opts.io = Some(record_path.to_str().expect("record path").to_string());
         game::run_with_options(opts).expect("replay matches");
     }


### PR DESCRIPTION
## Summary
- default the `--continue-after-mismatch` CLI flag to true and mirror the helper constructor
- keep replay golden tests in strict mode by opting out of the lenient default

## Testing
- cargo test -p game

------
https://chatgpt.com/codex/tasks/task_e_6900bf8a0688832ea181deca7f806f76