### PR TITLE
Gate FixedUpdate schedule executor for deterministic builds

### DIFF
--- a/crates/game/src/scheduling.rs
+++ b/crates/game/src/scheduling.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+#[cfg(feature = "deterministic")]
+use bevy::ecs::schedule::ExecutorKind;
+
 pub mod sets {
     #![allow(non_camel_case_types)]
     use bevy::prelude::SystemSet;
@@ -36,4 +39,11 @@ pub fn configure(app: &mut App) {
         )
             .chain(),
     );
+
+    #[cfg(feature = "deterministic")]
+    {
+        app.edit_schedule(FixedUpdate, |schedule| {
+            schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        });
+    }
 }

--- a/crates/game/tests/integration/schedule_order.rs
+++ b/crates/game/tests/integration/schedule_order.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
 
+#[cfg(feature = "deterministic")]
+use bevy::ecs::schedule::ExecutorKind;
+
 #[derive(Resource, Default)]
 struct OrderLog(Vec<&'static str>);
 
@@ -43,4 +46,16 @@ fn fixed_update_sets_chain_in_order() {
         log.0,
         vec!["director", "missions", "spawns", "physics", "cleanup"]
     );
+}
+
+#[cfg(feature = "deterministic")]
+#[test]
+fn fixed_update_executor_single_threaded_when_deterministic() {
+    let mut app = App::new();
+    game::scheduling::configure(&mut app);
+    app.finish();
+
+    app.edit_schedule(FixedUpdate, |schedule| {
+        assert_eq!(schedule.get_executor_kind(), ExecutorKind::SingleThreaded);
+    });
 }


### PR DESCRIPTION
## Summary
- set the FixedUpdate schedule executor to single-threaded when the deterministic feature is active
- add an integration test that validates the executor configuration under the deterministic feature

## Testing
- `cargo test -p game`
- `cargo test -p game --features deterministic`


------
https://chatgpt.com/codex/tasks/task_e_6901490578c8832e90707003fa3fbeb3