### PR TITLE
Add trading plugin skeleton

### DIFF
--- a/crates/game/src/lib.rs
+++ b/crates/game/src/lib.rs
@@ -23,6 +23,7 @@ use systems::command_queue::CommandQueue;
 use systems::director::director_cfg_path;
 use systems::director::{DirectorPlugin, DirectorState, LegContext, WheelState};
 use systems::economy::{Pp, RouteId, Weather};
+use systems::trading::TradingPlugin;
 
 pub fn run() -> Result<()> {
     let options = CliOptions::parse();
@@ -201,6 +202,7 @@ fn build_app(options: &CliOptions, context: LegContext) -> App {
     }
     app.init_resource::<CommandQueue>();
     app.insert_resource(context);
+    ensure_trading_plugin(&mut app);
     app.add_plugins(DirectorPlugin);
     app
 }
@@ -236,6 +238,7 @@ fn add_minimal_plugins(app: &mut App) {
     let plugins = configure_task_pool(plugins);
     app.add_plugins(plugins);
     app.add_plugins(bevy::input::InputPlugin);
+    ensure_trading_plugin(app);
 }
 
 #[derive(Default)]
@@ -243,6 +246,18 @@ struct WindowingPlaceholderPlugin;
 
 impl Plugin for WindowingPlaceholderPlugin {
     fn build(&self, _app: &mut App) {}
+}
+
+#[derive(Resource, Default)]
+struct TradingPluginMarker;
+
+fn ensure_trading_plugin(app: &mut App) {
+    if app.world().contains_resource::<TradingPluginMarker>() {
+        return;
+    }
+
+    app.add_plugins(TradingPlugin);
+    app.world_mut().insert_resource(TradingPluginMarker);
 }
 
 #[cfg(feature = "deterministic")]

--- a/crates/game/src/systems/economy/rulepack.rs
+++ b/crates/game/src/systems/economy/rulepack.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 
+use bevy::prelude::Resource;
 use blake3::Hasher;
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ use thiserror::Error;
 /// pricing power, etc.) and stores values primarily expressed in basis points
 /// (bp) unless otherwise noted. Basis points are interpreted as 1/100th of a
 /// percent (10_000 bp = 100%).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Resource)]
 #[serde(deny_unknown_fields)]
 pub struct Rulepack {
     /// Day-index configuration expressed in basis points.

--- a/crates/game/src/systems/economy/state.rs
+++ b/crates/game/src/systems/economy/state.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use bevy::prelude::Resource;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -19,7 +20,7 @@ use super::planting::PendingPlanting;
 const RNG_TAG_DI: u32 = 0;
 const RNG_TAG_BASIS: u32 = 1;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Resource)]
 pub struct EconState {
     pub day: EconomyDay,
     pub di_bp: HashMap<CommodityId, BasisBp>,

--- a/crates/game/src/systems/mod.rs
+++ b/crates/game/src/systems/mod.rs
@@ -3,3 +3,4 @@ pub mod director;
 pub mod economy;
 pub mod migrations;
 pub mod save;
+pub mod trading;

--- a/crates/game/src/systems/trading/inventory.rs
+++ b/crates/game/src/systems/trading/inventory.rs
@@ -1,0 +1,1 @@
+//! Trading inventory types land in the next patch; this file acts as a stub.

--- a/crates/game/src/systems/trading/mod.rs
+++ b/crates/game/src/systems/trading/mod.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+
+use crate::systems::economy::{load_rulepack, EconState, Rulepack};
+
+pub mod inventory;
+pub mod pricing_vm;
+pub mod types;
+
+#[allow(unused_imports)]
+pub use inventory::*;
+#[allow(unused_imports)]
+pub use pricing_vm::*;
+#[allow(unused_imports)]
+pub use types::*;
+
+/// Bevy plugin that wires the trading subsystem into the core simulation.
+///
+/// The plugin ensures that read-only trading resources sourced from the
+/// existing economy module are initialised exactly once. These resources are
+/// required by forthcoming trading systems (pricing view models, inventory
+/// management, etc.) and remain immutable so that no cyclic dependencies are
+/// introduced between trading and economy code.
+pub struct TradingPlugin;
+
+impl Plugin for TradingPlugin {
+    fn build(&self, app: &mut App) {
+        initialise_resources(app);
+    }
+}
+
+fn initialise_resources(app: &mut App) {
+    let world = app.world_mut();
+
+    if !world.contains_resource::<EconState>() {
+        world.insert_resource(EconState::default());
+    }
+
+    if !world.contains_resource::<Rulepack>() {
+        let path = default_rulepack_path();
+        let path_str = path
+            .to_str()
+            .unwrap_or_else(|| panic!("rulepack path is not valid UTF-8: {}", path.display()));
+        let rulepack = load_rulepack(path_str).unwrap_or_else(|err| {
+            panic!(
+                "failed to load trading rulepack from {}: {err}",
+                path.display()
+            )
+        });
+        world.insert_resource(rulepack);
+    }
+}
+
+fn default_rulepack_path() -> PathBuf {
+    const DEFAULT: &str = "assets/rulepacks/day_001.toml";
+    let candidate = Path::new(DEFAULT);
+    if candidate.exists() {
+        return candidate.to_path_buf();
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{DEFAULT}"))
+}

--- a/crates/game/src/systems/trading/pricing_vm.rs
+++ b/crates/game/src/systems/trading/pricing_vm.rs
@@ -1,0 +1,1 @@
+//! Read-only pricing view-model helpers will be added in a follow-up patch.

--- a/crates/game/src/systems/trading/types.rs
+++ b/crates/game/src/systems/trading/types.rs
@@ -1,0 +1,1 @@
+//! Trading-facing type definitions will live here in subsequent patches.


### PR DESCRIPTION
## Summary
- add a trading plugin that initialises shared economy resources and re-exports placeholder trading modules
- expose the trading module from the systems tree and hook the plugin into both headless and windowed app startup paths
- mark the economy state and rulepack types as Bevy resources so trading systems can access them read-only

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_6901622f58c4832e98186d400a90c699