### PR TITLE
Add canonical trading commodities dataset and loader

### DIFF
--- a/assets/trading/commodities.toml
+++ b/assets/trading/commodities.toml
@@ -1,0 +1,44 @@
+[[commodity]]
+id = 1
+slug = "grain"
+display_name = "Grain"
+
+[[commodity]]
+id = 2
+slug = "textiles"
+display_name = "Textiles"
+
+[[commodity]]
+id = 3
+slug = "lumber"
+display_name = "Lumber"
+
+[[commodity]]
+id = 4
+slug = "metals"
+display_name = "Metals"
+
+[[commodity]]
+id = 5
+slug = "electronics"
+display_name = "Electronics"
+
+[[commodity]]
+id = 6
+slug = "chemicals"
+display_name = "Chemicals"
+
+[[commodity]]
+id = 7
+slug = "pharmaceuticals"
+display_name = "Pharmaceuticals"
+
+[[commodity]]
+id = 8
+slug = "luxury_goods"
+display_name = "Luxury Goods"
+
+[[commodity]]
+id = 9
+slug = "energy_cells"
+display_name = "Energy Cells"

--- a/crates/game/src/systems/trading/mod.rs
+++ b/crates/game/src/systems/trading/mod.rs
@@ -50,6 +50,20 @@ fn initialise_resources(app: &mut App) {
         });
         world.insert_resource(rulepack);
     }
+
+    if !world.contains_resource::<types::Commodities>() {
+        let path = default_commodities_path();
+        let path_str = path
+            .to_str()
+            .unwrap_or_else(|| panic!("commodities path is not valid UTF-8: {}", path.display()));
+        let commodities = types::load_commodities(path_str).unwrap_or_else(|err| {
+            panic!(
+                "failed to load commodity specs from {}: {err}",
+                path.display()
+            )
+        });
+        world.insert_resource(commodities);
+    }
 }
 
 fn default_rulepack_path() -> PathBuf {
@@ -61,3 +75,16 @@ fn default_rulepack_path() -> PathBuf {
 
     Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{DEFAULT}"))
 }
+
+fn default_commodities_path() -> PathBuf {
+    const DEFAULT: &str = "assets/trading/commodities.toml";
+    let candidate = Path::new(DEFAULT);
+    if candidate.exists() {
+        return candidate.to_path_buf();
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../{DEFAULT}"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/game/src/systems/trading/tests/commodities_loader.rs
+++ b/crates/game/src/systems/trading/tests/commodities_loader.rs
@@ -1,0 +1,19 @@
+use std::io::Write;
+
+use tempfile::NamedTempFile;
+
+use crate::systems::trading::load_commodities;
+
+#[test]
+fn rejects_unknown_fields() {
+    let mut tmp = NamedTempFile::new().expect("tmp file");
+    write!(
+        tmp,
+        "[[commodity]]\nid = 1\nslug = \"grain\"\ndisplay_name = \"Grain\"\nunknown_key = \"nope\"\n"
+    )
+    .expect("write tmp");
+
+    let err = load_commodities(tmp.path().to_str().unwrap()).expect_err("should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("unknown"), "unexpected error: {}", msg);
+}

--- a/crates/game/src/systems/trading/tests/mod.rs
+++ b/crates/game/src/systems/trading/tests/mod.rs
@@ -1,0 +1,1 @@
+mod commodities_loader;

--- a/crates/game/src/systems/trading/types.rs
+++ b/crates/game/src/systems/trading/types.rs
@@ -1,1 +1,84 @@
-//! Trading-facing type definitions will live here in subsequent patches.
+use std::fs;
+
+use bevy::prelude::Resource;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::systems::economy::CommodityId;
+
+/// Canonical metadata describing a tradable commodity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommoditySpec {
+    pub id: CommodityId,
+    pub slug: String,
+    pub display_name: String,
+}
+
+impl CommoditySpec {
+    /// Stable numeric identifier that links back to the economy layer.
+    pub fn id(&self) -> CommodityId {
+        self.id
+    }
+
+    /// Human-readable slug that can be used for lookups and localisation keys.
+    pub fn slug(&self) -> &str {
+        &self.slug
+    }
+
+    /// Display name suitable for UI surfaces.
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+}
+
+/// Collection of tradable commodity specifications loaded from disk.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Resource)]
+#[serde(deny_unknown_fields)]
+pub struct Commodities {
+    #[serde(default, rename = "commodity")]
+    entries: Vec<CommoditySpec>,
+}
+
+impl Commodities {
+    /// Returns an iterator over all known commodity specifications.
+    pub fn iter(&self) -> impl Iterator<Item = &CommoditySpec> {
+        self.entries.iter()
+    }
+
+    /// Number of commodities defined in the dataset.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the dataset is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Finds a commodity specification by its numeric identifier.
+    pub fn get_by_id(&self, id: CommodityId) -> Option<&CommoditySpec> {
+        self.entries.iter().find(|spec| spec.id == id)
+    }
+
+    /// Finds a commodity specification by its slug.
+    pub fn get_by_slug(&self, slug: &str) -> Option<&CommoditySpec> {
+        self.entries.iter().find(|spec| spec.slug == slug)
+    }
+}
+
+/// Errors that can occur when loading commodity specifications from disk.
+#[derive(Debug, Error)]
+pub enum CommodityLoadError {
+    #[error("failed to read commodities: {0}")]
+    Read(#[from] std::io::Error),
+    #[error("failed to parse commodities: {0}")]
+    Parse(#[from] toml::de::Error),
+}
+
+/// Loads the canonical set of tradable commodities from a TOML file.
+pub fn load_commodities(path: &str) -> Result<Commodities, CommodityLoadError> {
+    let raw = fs::read_to_string(path)?;
+    let commodities: Commodities = toml::from_str(&raw)?;
+    Ok(commodities)
+}


### PR DESCRIPTION
## Summary
- define the trading commodity schema and loader helpers in `types.rs`
- add the canonical `assets/trading/commodities.toml` dataset and load it during plugin startup
- cover the loader with a unit test that fails on unknown fields

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_69017ad3b864832eb9908496291ae8a5