### PR TITLE
Fix clippy warnings for economy state initialization

### DIFF
--- a/crates/game/src/systems/save/mod.rs
+++ b/crates/game/src/systems/save/mod.rs
@@ -151,23 +151,28 @@ pub fn snapshot_from_app_state(state: &AppState) -> SaveV11 {
 }
 
 pub fn app_state_from_snapshot(snapshot: SaveV11) -> AppState {
-    let mut econ = EconState::default();
-    econ.day = snapshot.day;
-    econ.di_bp = snapshot
+    let di_bp = snapshot
         .di
         .iter()
         .map(|entry| (entry.commodity, entry.value))
         .collect();
-    econ.di_overlay_bp = snapshot.di_overlay_bp;
-    econ.basis_bp = snapshot
+    let basis_bp = snapshot
         .basis
         .iter()
         .map(|entry| ((entry.hub, entry.commodity), entry.value))
         .collect();
-    econ.pp = snapshot.pp;
-    econ.rot_u16 = snapshot.rot;
-    econ.pending_planting = snapshot.pending_planting.clone();
-    econ.debt_cents = snapshot.debt_cents;
+
+    let econ = EconState {
+        day: snapshot.day,
+        di_bp,
+        di_overlay_bp: snapshot.di_overlay_bp,
+        basis_bp,
+        pp: snapshot.pp,
+        rot_u16: snapshot.rot,
+        pending_planting: snapshot.pending_planting.clone(),
+        debt_cents: snapshot.debt_cents,
+        ..Default::default()
+    };
 
     AppState {
         econ_version: snapshot.econ_version,

--- a/crates/game/src/systems/trading/pricing_vm.rs
+++ b/crates/game/src/systems/trading/pricing_vm.rs
@@ -35,7 +35,7 @@ pub fn price_view(hub: HubId, com: CommodityId, econ: &EconState, rp: &Rulepack)
         .basis_drivers
         .get(&hub)
         .copied()
-        .unwrap_or_else(|| BasisDrivers {
+        .unwrap_or(BasisDrivers {
             pp: econ.pp,
             weather: Weather::Clear,
             closed_routes: 0,

--- a/crates/game/tests/integration/save_load_integration.rs
+++ b/crates/game/tests/integration/save_load_integration.rs
@@ -33,25 +33,27 @@ fn load_rulepack_fixture() -> game::systems::economy::Rulepack {
 }
 
 fn sample_app_state() -> AppState {
-    let mut econ = EconState::default();
-    econ.day = game::systems::economy::EconomyDay(3);
-    econ.di_bp = HashMap::from([
-        (CommodityId(1), BasisBp(120)),
-        (CommodityId(2), BasisBp(-80)),
-    ]);
-    econ.di_overlay_bp = 90;
-    econ.basis_bp = HashMap::from([
-        ((HubId(1), CommodityId(1)), BasisBp(45)),
-        ((HubId(1), CommodityId(2)), BasisBp(-30)),
-    ]);
-    econ.pp = Pp(5_100);
-    econ.rot_u16 = 12;
-    econ.pending_planting = vec![PendingPlanting {
-        hub: HubId(1),
-        size: 4,
-        age_days: 2,
-    }];
-    econ.debt_cents = MoneyCents(4_200);
+    let econ = EconState {
+        day: game::systems::economy::EconomyDay(3),
+        di_bp: HashMap::from([
+            (CommodityId(1), BasisBp(120)),
+            (CommodityId(2), BasisBp(-80)),
+        ]),
+        di_overlay_bp: 90,
+        basis_bp: HashMap::from([
+            ((HubId(1), CommodityId(1)), BasisBp(45)),
+            ((HubId(1), CommodityId(2)), BasisBp(-30)),
+        ]),
+        pp: Pp(5_100),
+        rot_u16: 12,
+        pending_planting: vec![PendingPlanting {
+            hub: HubId(1),
+            size: 4,
+            age_days: 2,
+        }],
+        debt_cents: MoneyCents(4_200),
+        ..Default::default()
+    };
 
     AppState {
         econ_version: 7,

--- a/crates/game/tests/trading_replay.rs
+++ b/crates/game/tests/trading_replay.rs
@@ -7,7 +7,7 @@ use game::app_state::AppState;
 use game::systems::command_queue::CommandQueue;
 use game::systems::economy::rulepack::load_rulepack;
 use game::systems::economy::{
-    step_economy_day, BasisBp, CommodityId, EconStepScope, HubId, MoneyCents, Pp,
+    step_economy_day, BasisBp, CommodityId, EconState, EconStepScope, HubId, MoneyCents, Pp,
 };
 use game::systems::trading::engine::{TradeKind, TradeResult, TradeTx};
 use game::systems::trading::inventory::Cargo;
@@ -161,37 +161,43 @@ fn seeded_app_state(seed: u64) -> AppState {
     use game::systems::economy::state::RngCursor;
     use game::systems::economy::EconomyDay;
 
-    let mut state = AppState::default();
-    state.econ_version = 7;
-    state.world_seed = 0x5000_0000 + seed;
-    state.last_hub = HUB;
-    state.wallet = MoneyCents(200_000 + (seed as i64) * 1_000);
-    state.econ.day = EconomyDay(2 + seed as u32);
-    state.econ.di_bp = HashMap::from([
-        (CommodityId(1), BasisBp(100 + (seed as i32) * 10)),
-        (CommodityId(2), BasisBp(-60 + (seed as i32) * 5)),
-        (CommodityId(3), BasisBp(25 - (seed as i32) * 3)),
-    ]);
-    state.econ.di_overlay_bp = 45 + seed as i32;
-    state.econ.basis_bp = HashMap::from([
-        ((HUB, CommodityId(1)), BasisBp(30 + (seed as i32) * 4)),
-        ((HUB, CommodityId(2)), BasisBp(-20 + (seed as i32) * 2)),
-        ((HUB, CommodityId(3)), BasisBp(10 - (seed as i32))),
-    ]);
-    state.econ.pp = Pp(5_000 + (seed as u16) * 150);
-    state.econ.rot_u16 = 8 + seed as u16;
-    state.econ.pending_planting = vec![];
-    state.econ.debt_cents = MoneyCents(10_000 + (seed as i64) * 500);
-    state.rng_cursors = vec![RngCursor {
-        label: "di".to_string(),
-        draws: (12 + seed as u32),
-    }];
-    state.cargo = Cargo {
-        capacity_mass_kg: 600,
-        capacity_volume_l: 400,
-        items: HashMap::from([(CommodityId(2), 1 + seed as u32)]),
+    let econ = EconState {
+        day: EconomyDay(2 + seed as u32),
+        di_bp: HashMap::from([
+            (CommodityId(1), BasisBp(100 + (seed as i32) * 10)),
+            (CommodityId(2), BasisBp(-60 + (seed as i32) * 5)),
+            (CommodityId(3), BasisBp(25 - (seed as i32) * 3)),
+        ]),
+        di_overlay_bp: 45 + seed as i32,
+        basis_bp: HashMap::from([
+            ((HUB, CommodityId(1)), BasisBp(30 + (seed as i32) * 4)),
+            ((HUB, CommodityId(2)), BasisBp(-20 + (seed as i32) * 2)),
+            ((HUB, CommodityId(3)), BasisBp(10 - (seed as i32))),
+        ]),
+        pp: Pp(5_000 + (seed as u16) * 150),
+        rot_u16: 8 + seed as u16,
+        pending_planting: vec![],
+        debt_cents: MoneyCents(10_000 + (seed as i64) * 500),
+        ..Default::default()
     };
-    state
+
+    AppState {
+        econ_version: 7,
+        world_seed: 0x5000_0000 + seed,
+        econ,
+        last_hub: HUB,
+        inventory: Vec::new(),
+        cargo: Cargo {
+            capacity_mass_kg: 600,
+            capacity_volume_l: 400,
+            items: HashMap::from([(CommodityId(2), 1 + seed as u32)]),
+        },
+        rng_cursors: vec![RngCursor {
+            label: "di".to_string(),
+            draws: 12 + seed as u32,
+        }],
+        wallet: MoneyCents(200_000 + (seed as i64) * 1_000),
+    }
 }
 
 fn scripted_buys(seed: u64) -> Vec<TradeTx> {


### PR DESCRIPTION
## Summary
- build economy state snapshots using struct literals instead of mutating defaults
- simplify trading price driver fallback to use `unwrap_or`
- update save/load and trading replay tests to construct app state via struct literals

## Testing
- cargo clippy --workspace --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_69021b48434c832e937c2235e3f5f554