### PR TITLE
Add trading documentation and contributor reminders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
 ## Economy invariants
 - `crates/game/src/systems/economy/**` must stay free of `f32`/`f64` usage; CI enforces this via the Clippy lint configuration (`crates/game/Cargo.toml` and `ci/.clippy.toml`).
 - The `game` crate denies `clippy::float_arithmetic` globally. When non-economy code truly needs floats (UI readouts, perf tooling, etc.), add a module-level `#![allow(clippy::float_arithmetic)]` plus a short comment that explains the exception before landing the change.
+- Trading price paths (`crates/game/src/systems/trading/**`) inherit the same "no floats" rule. Quote calculation, wallet math, fee accrual, and capacity enforcement must stay on `MoneyCents`/integer types so deterministic rounding holds end-to-end.
 - Seed all economy simulations through `DetRng`; CI's `ci/grep_banned_random.sh` blocks `thread_rng`/`rand::random` in that tree.
 - Breaking either rule fails the `Economy invariants` job in the main workflow alongside the determinism checks.
 
@@ -31,6 +32,14 @@
   DETTEROT_UPDATE_GOLDENS=1 cargo test -p game --features deterministic --test trading_replay
   ```
 - Inspect the changes, rerun the test without the environment variable to confirm the new outputs, and commit the refreshed goldens alongside the code change.
+
+## Refreshing save migrations
+- Save schema migrations live under `crates/game/src/systems/migrations/` and are exercised by the integration test suite.
+- When a migration or save schema update lands, rerun the byte-stability guard and commit any fixture updates:
+  ```
+  cargo test -p game migrate_roundtrip
+  ```
+- Document the schema bump in `docs/plan_changelog.md` and update any deterministic config hashes affected by the change.
 
 ## Formatting
 - Run `cargo fmt --all` locally before pushing to avoid CI failures on the formatting check.

--- a/docs/plan_changelog.md
+++ b/docs/plan_changelog.md
@@ -1,5 +1,9 @@
 # Planning changelog
 
+## v1.2.0 (M3 implemented)
+- Deterministic builds now emit the BLAKE3 hash of the director configuration at startup so replay traces can pin the exact mission config set.【F:crates/game/src/lib.rs†L322-L369】
+- Save loading funnels every legacy payload through the migrator, which dispatches on the embedded schema version and upgrades 1.0 saves into the 1.1 format automatically.【F:crates/game/src/systems/migrations/mod.rs†L1-L42】
+
 ## v1.1.0 (Save schema refresh)
 - Bumped the save-game schema to v1.1 with explicit metadata headers.
 - Captured the player's last visited hub and cargo manifest for trading persistence.

--- a/docs/trading.md
+++ b/docs/trading.md
@@ -1,0 +1,41 @@
+# Trading systems guide
+
+## Price policy and drivers
+- Trades quote prices through the deterministic `PriceView`, which feeds the
+  current daily index (DI) and hub basis multipliers into `compute_price` while
+  keeping all math in integer `MoneyCents` units (no floats in the price path).
+  【F:crates/game/src/systems/trading/pricing_vm.rs†L8-L47】【F:crates/game/src/systems/economy/pricing.rs†L9-L33】
+- Driver inputs (DI + basis) are clamped to the rulepack's multiplier bounds
+  before applying the integer multiplier to the base price, preventing runaway
+  quotes when the economy spikes.【F:crates/game/src/systems/economy/pricing.rs†L14-L23】
+
+## Rounding guarantees
+- Quotes scale the base price into milli-cents, apply banker's rounding on
+  half-cent ties, and then perform a final downward clamp to ensure no residual
+  fractions survive beyond a cent.【F:crates/game/src/systems/economy/pricing.rs†L21-L34】【F:crates/game/src/systems/economy/rounding.rs†L5-L19】
+- All intermediate products go through `MoneyCents::from_i128_clamped`, so
+  integer overflow collapses into the signed 64-bit bounds instead of wrapping
+  or panicking.【F:crates/game/src/systems/economy/money.rs†L11-L28】【F:crates/game/src/systems/trading/engine.rs†L96-L109】
+
+## Transaction fees
+- Executed trades compute gross notional via saturating integer multiplication
+  and apply the transaction fee basis points using the same integer scaling,
+  guaranteeing fee math matches price rounding and never introduces floats.【F:crates/game/src/systems/trading/engine.rs†L80-L109】
+- Fee calculations share the clamped arithmetic path, so extreme wallet sizes or
+  fee settings cannot overflow the accumulator.【F:crates/game/src/systems/trading/engine.rs†L96-L109】
+
+## Capacity rules
+- Buy orders enforce three independent limits before any units fill: remaining
+  cargo volume, remaining cargo mass, and wallet affordability under the fee
+  schedule. The engine executes the minimum of those caps, so breaching any one
+  limit short-circuits the fill.【F:crates/game/src/systems/trading/engine.rs†L53-L85】
+- Sell orders are capped by existing inventory units, preventing negative cargo
+  balances even if the caller requests more than the manifest holds.【F:crates/game/src/systems/trading/engine.rs†L86-L94】
+- After execution, the engine applies saturating updates to cargo capacity usage
+  and wallet balances so post-trade state stays within the configured bounds.【F:crates/game/src/systems/trading/engine.rs†L110-L152】
+
+## Wallet affordability search
+- Wallet checks use a binary search against the integer fee-inclusive trade
+  cost, ensuring the affordability gate stays deterministic and converges without
+  float math. Costs share the same clamped multiplication and fee logic as final
+  execution.【F:crates/game/src/systems/trading/engine.rs†L114-L199】


### PR DESCRIPTION
## Summary
- add a trading systems guide outlining price policy, rounding, clamps, fees, and capacity limits
- remind contributors that trading code stays on integer price math and document how to refresh goldens/migrations
- record the M3 implementation milestone with the config hash logging and save migration requirements

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_6902ace25648832e97608fadc9ec0d51