### PR TITLE
Seed hub trade catalog from commodity specs

### DIFF
--- a/assets/trading/commodities.toml
+++ b/assets/trading/commodities.toml
@@ -2,43 +2,70 @@
 id = 1
 slug = "grain"
 display_name = "Grain"
+base_price_cents = 250
+mass_per_unit_kg = 2
+volume_per_unit_l = 4
 
 [[commodity]]
 id = 2
 slug = "textiles"
 display_name = "Textiles"
+base_price_cents = 400
+mass_per_unit_kg = 1
+volume_per_unit_l = 1
 
 [[commodity]]
 id = 3
 slug = "lumber"
 display_name = "Lumber"
+base_price_cents = 320
+mass_per_unit_kg = 3
+volume_per_unit_l = 5
 
 [[commodity]]
 id = 4
 slug = "metals"
 display_name = "Metals"
+base_price_cents = 500
+mass_per_unit_kg = 5
+volume_per_unit_l = 2
 
 [[commodity]]
 id = 5
 slug = "electronics"
 display_name = "Electronics"
+base_price_cents = 650
+mass_per_unit_kg = 1
+volume_per_unit_l = 1
 
 [[commodity]]
 id = 6
 slug = "chemicals"
 display_name = "Chemicals"
+base_price_cents = 420
+mass_per_unit_kg = 2
+volume_per_unit_l = 2
 
 [[commodity]]
 id = 7
 slug = "pharmaceuticals"
 display_name = "Pharmaceuticals"
+base_price_cents = 900
+mass_per_unit_kg = 1
+volume_per_unit_l = 1
 
 [[commodity]]
 id = 8
 slug = "luxury_goods"
 display_name = "Luxury Goods"
+base_price_cents = 1200
+mass_per_unit_kg = 1
+volume_per_unit_l = 1
 
 [[commodity]]
 id = 9
 slug = "energy_cells"
 display_name = "Energy Cells"
+base_price_cents = 280
+mass_per_unit_kg = 1
+volume_per_unit_l = 3

--- a/crates/game/src/systems/trading/mod.rs
+++ b/crates/game/src/systems/trading/mod.rs
@@ -6,7 +6,7 @@ use crate::scheduling::sets;
 use crate::systems::app_state::AppStatePlugin;
 use crate::systems::economy::{load_rulepack, EconState, Rulepack};
 use crate::systems::trading::inventory::Cargo;
-use crate::ui::hub_trade::HubTradeUiPlugin;
+use crate::ui::hub_trade::{HubTradeCatalog, HubTradeUiPlugin};
 use crate::ui::route_planner::RoutePlannerUiPlugin;
 use crate::world::WorldIndex;
 
@@ -83,12 +83,14 @@ impl Plugin for TradingPlugin {
     fn build(&self, app: &mut App) {
         initialise_resources(app);
         app.init_resource::<TradingViewState>()
+            .init_resource::<HubTradeCatalog>()
             .add_message::<EnterTradingViewEvent>()
             .add_message::<EnterRoutePlannerViewEvent>()
             .add_systems(
                 FixedUpdate,
                 apply_trading_view_events.in_set(sets::DETTEROT_Input),
             )
+            .add_systems(Startup, seed_hub_trade_catalog)
             .add_plugins(HubTradeUiPlugin)
             .add_plugins(RoutePlannerUiPlugin)
             .add_plugins(AppStatePlugin);
@@ -144,6 +146,13 @@ fn initialise_resources(app: &mut App) {
     if !world.contains_resource::<Cargo>() {
         world.insert_resource(Cargo::default());
     }
+}
+
+fn seed_hub_trade_catalog(
+    mut catalog: ResMut<HubTradeCatalog>,
+    commodities: Res<types::Commodities>,
+) {
+    catalog.rebuild_from_specs(&commodities);
 }
 
 fn apply_trading_view_events(

--- a/crates/game/src/systems/trading/tests/commodities_loader.rs
+++ b/crates/game/src/systems/trading/tests/commodities_loader.rs
@@ -9,7 +9,7 @@ fn rejects_unknown_fields() {
     let mut tmp = NamedTempFile::new().expect("tmp file");
     write!(
         tmp,
-        "[[commodity]]\nid = 1\nslug = \"grain\"\ndisplay_name = \"Grain\"\nunknown_key = \"nope\"\n"
+        "[[commodity]]\nid = 1\nslug = \"grain\"\ndisplay_name = \"Grain\"\nbase_price_cents = 250\nmass_per_unit_kg = 2\nvolume_per_unit_l = 4\nunknown_key = \"nope\"\n"
     )
     .expect("write tmp");
 

--- a/crates/game/src/systems/trading/types.rs
+++ b/crates/game/src/systems/trading/types.rs
@@ -4,7 +4,7 @@ use bevy::prelude::Resource;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::systems::economy::CommodityId;
+use crate::systems::economy::{CommodityId, MoneyCents};
 
 /// Canonical metadata describing a tradable commodity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -13,6 +13,9 @@ pub struct CommoditySpec {
     pub id: CommodityId,
     pub slug: String,
     pub display_name: String,
+    pub base_price_cents: i64,
+    pub mass_per_unit_kg: u32,
+    pub volume_per_unit_l: u32,
 }
 
 impl CommoditySpec {
@@ -29,6 +32,21 @@ impl CommoditySpec {
     /// Display name suitable for UI surfaces.
     pub fn display_name(&self) -> &str {
         &self.display_name
+    }
+
+    /// Base price (in cents) used as the anchor for quote calculations.
+    pub fn base_price(&self) -> MoneyCents {
+        MoneyCents(self.base_price_cents)
+    }
+
+    /// Per-unit mass measured in kilograms.
+    pub fn mass_per_unit_kg(&self) -> u32 {
+        self.mass_per_unit_kg
+    }
+
+    /// Per-unit volume measured in litres.
+    pub fn volume_per_unit_l(&self) -> u32 {
+        self.volume_per_unit_l
     }
 }
 

--- a/crates/game/src/ui/hub_trade.rs
+++ b/crates/game/src/ui/hub_trade.rs
@@ -81,6 +81,10 @@ pub struct HubTradeCatalog {
 }
 
 impl HubTradeCatalog {
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
     pub fn insert(
         &mut self,
         commodity: CommodityId,
@@ -100,6 +104,18 @@ impl HubTradeCatalog {
 
     pub fn get(&self, commodity: CommodityId) -> Option<&CommodityMarketMetadata> {
         self.entries.get(&commodity)
+    }
+
+    pub fn rebuild_from_specs(&mut self, specs: &Commodities) {
+        self.clear();
+        for spec in specs.iter() {
+            self.insert(
+                spec.id(),
+                spec.base_price(),
+                spec.volume_per_unit_l(),
+                spec.mass_per_unit_kg(),
+            );
+        }
     }
 }
 

--- a/crates/game/src/ui/tests/buy_sell_flow_headless.rs
+++ b/crates/game/src/ui/tests/buy_sell_flow_headless.rs
@@ -47,10 +47,11 @@ fn buying_and_selling_updates_inventory_and_wallet() {
     econ.basis_bp.insert((HubId(1), CommodityId(1)), BasisBp(0));
     app.insert_resource(econ);
     app.insert_resource(load_rulepack());
-    app.insert_resource(load_commodities(&load_specs_path()).unwrap());
+    let specs = load_commodities(&load_specs_path()).unwrap();
+    app.insert_resource(specs.clone());
 
     let mut catalog = HubTradeCatalog::default();
-    catalog.insert(CommodityId(1), MoneyCents(250), 4, 2);
+    catalog.rebuild_from_specs(&specs);
     app.insert_resource(catalog);
 
     let mut cargo = Cargo::default();

--- a/crates/game/src/ui/tests/ui_vm_shape.rs
+++ b/crates/game/src/ui/tests/ui_vm_shape.rs
@@ -55,11 +55,11 @@ fn view_models_reflect_resources() {
     app.insert_resource(econ);
 
     app.insert_resource(load_rulepack());
-    app.insert_resource(load_specs());
+    let specs = load_specs();
+    app.insert_resource(specs.clone());
 
     let mut catalog = HubTradeCatalog::default();
-    catalog.insert(CommodityId(1), MoneyCents(250), 2, 3);
-    catalog.insert(CommodityId(2), MoneyCents(400), 1, 1);
+    catalog.rebuild_from_specs(&specs);
     app.insert_resource(catalog);
 
     let mut cargo = Cargo::default();
@@ -90,18 +90,27 @@ fn view_models_reflect_resources() {
     assert_eq!(grain.di_bp, 120);
 
     let list = &vm.commodity_list;
-    assert_eq!(list.selected, Some(0));
-    assert_eq!(list.rows.len(), 2);
-    let first_row = &list.rows[0];
-    assert_eq!(first_row.commodity, CommodityId(1));
-    assert!(first_row.can_buy);
-    assert!(first_row.can_sell);
-    assert!(first_row.max_buy >= 1);
-    assert_eq!(first_row.held_units, 4);
+    assert!(list.rows.len() >= 2);
+    let selected_index = list.selected.expect("selected index");
+    let selected_row = &list.rows[selected_index];
+    assert_eq!(selected_row.commodity, CommodityId(1));
 
-    let second_row = &list.rows[1];
-    assert_eq!(second_row.commodity, CommodityId(2));
-    assert!(second_row.can_sell);
+    let grain_row = list
+        .rows
+        .iter()
+        .find(|row| row.commodity == CommodityId(1))
+        .expect("grain row present");
+    assert!(grain_row.can_buy);
+    assert!(grain_row.can_sell);
+    assert!(grain_row.max_buy >= 1);
+    assert_eq!(grain_row.held_units, 4);
+
+    let textiles_row = list
+        .rows
+        .iter()
+        .find(|row| row.commodity == CommodityId(2))
+        .expect("textiles row present");
+    assert!(textiles_row.can_sell);
 
     assert_eq!(vm.cargo_panel.capacity_total, 120);
     assert_eq!(vm.wallet_panel.balance, MoneyCents(25_000));

--- a/crates/game/tests/integration/save_load_integration.rs
+++ b/crates/game/tests/integration/save_load_integration.rs
@@ -13,9 +13,7 @@ use game::systems::save::{
 use game::systems::trading::inventory::Cargo;
 use game::systems::trading::types::load_commodities;
 use game::systems::trading::{EnterRoutePlannerViewEvent, TradingPlugin};
-use game::ui::hub_trade::{
-    ActiveHub, BuyUnitsEvent, HubTradeCatalog, SellUnitsEvent, WalletBalance,
-};
+use game::ui::hub_trade::{ActiveHub, BuyUnitsEvent, SellUnitsEvent, WalletBalance};
 
 fn asset_path(relative: &str) -> String {
     let direct = PathBuf::from(relative);
@@ -83,11 +81,6 @@ fn trade_save_load_roundtrip() {
         econ.di_bp.insert(CommodityId(1), BasisBp(0));
         econ.basis_bp.insert((HubId(1), CommodityId(1)), BasisBp(0));
     }
-    {
-        let mut catalog = app.world_mut().resource_mut::<HubTradeCatalog>();
-        catalog.insert(CommodityId(1), MoneyCents(250), 4, 2);
-    }
-
     app.update();
 
     {
@@ -173,11 +166,6 @@ fn trade_save_load_roundtrip() {
         econ.di_bp.insert(CommodityId(1), BasisBp(0));
         econ.basis_bp.insert((HubId(1), CommodityId(1)), BasisBp(0));
     }
-    {
-        let mut catalog = app.world_mut().resource_mut::<HubTradeCatalog>();
-        catalog.insert(CommodityId(1), MoneyCents(250), 4, 2);
-    }
-
     app.update();
 
     {


### PR DESCRIPTION
## Summary
- extend commodity specifications with base price, mass, and volume metadata and update the TOML dataset
- rebuild the hub trade catalog from the loaded specs and seed it during TradingPlugin startup
- update trading UI and integration tests plus loader checks for the stricter commodity schema

## Testing
- cargo test --package game

------
https://chatgpt.com/codex/tasks/task_e_6902b565654c832e9b727c74928b8419