### PR TITLE
Refactor trading price view structure

### DIFF
--- a/crates/game/src/systems/trading/engine.rs
+++ b/crates/game/src/systems/trading/engine.rs
@@ -49,12 +49,12 @@ impl TradeResult {
 /// volume, and wallet constraints.
 pub fn execute_trade(
     tx: &TradeTx,
-    view: &PriceView<'_>,
+    view: &PriceView,
     rulepack: &Rulepack,
     cargo: &mut Cargo,
     wallet: &mut MoneyCents,
 ) -> Result<TradeResult> {
-    let unit_price = view.quote(tx.hub, tx.commodity, tx.base_price);
+    let unit_price = view.price_cents();
     if tx.units == 0 {
         return Ok(TradeResult::empty(unit_price));
     }

--- a/crates/game/src/systems/trading/pricing_vm.rs
+++ b/crates/game/src/systems/trading/pricing_vm.rs
@@ -1,85 +1,100 @@
-use std::collections::HashMap;
-
 use crate::systems::economy::{
-    compute_price, rulepack::PricingCfg, BasisBp, CommodityId, EconState, HubId, MoneyCents, Pp,
-    Weather,
+    compute_price,
+    rulepack::{BasisCfg, PricingCfg, Rulepack},
+    BasisBp, CommodityId, EconState, HubId, MoneyCents, Pp, Weather,
 };
 
-/// Read-only view over the economy pricing inputs required to quote trades.
-///
-/// The view borrows the large DI/Basis hash maps from the [`EconState`] so
-/// that downstream systems can perform pricing lookups without cloning the
-/// underlying state. Driver style scalar inputs (PP, weather, route closures,
-/// stock deviation) are exposed via accessors to emphasise the read-only
-/// nature of the view.
-pub struct PriceView<'a> {
-    di_bp: &'a HashMap<CommodityId, BasisBp>,
-    basis_bp: &'a HashMap<(HubId, CommodityId), BasisBp>,
-    pricing: &'a PricingCfg,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TradingDrivers {
     pp: Pp,
     weather: Weather,
     closed_routes: u8,
     stock_dev: i32,
 }
 
-impl<'a> PriceView<'a> {
-    /// Returns the global daily index (DI) multiplier for a commodity.
-    pub fn di_bp(&self, commodity: CommodityId) -> BasisBp {
-        self.di_bp.get(&commodity).copied().unwrap_or(BasisBp(0))
-    }
-
-    /// Returns the hub-specific basis multiplier for a commodity quote.
-    pub fn basis_bp(&self, hub: HubId, commodity: CommodityId) -> BasisBp {
-        self.basis_bp
-            .get(&(hub, commodity))
-            .copied()
-            .unwrap_or(BasisBp(0))
-    }
-
-    /// Player power driver extracted from the economy state.
+impl TradingDrivers {
     pub fn pp(&self) -> Pp {
         self.pp
     }
 
-    /// Active weather driver affecting basis calculations.
     pub fn weather(&self) -> Weather {
         self.weather
     }
 
-    /// Number of currently closed trade routes acting as a driver.
     pub fn closed_routes(&self) -> u8 {
         self.closed_routes
     }
 
-    /// Warehouse stock deviation driver contributing to basis moves.
     pub fn stock_dev(&self) -> i32 {
         self.stock_dev
     }
+}
 
-    /// Computes a quoted transaction price by applying the current DI and basis
-    /// multipliers to the provided base price.
-    pub fn quote(&self, hub: HubId, commodity: CommodityId, base_price: MoneyCents) -> MoneyCents {
-        let di = self.di_bp(commodity);
-        let basis = self.basis_bp(hub, commodity);
-        compute_price(base_price, di, basis, self.pricing)
+/// Read-only view over the pricing inputs relevant to a single
+/// `(hub, commodity)` quote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PriceView {
+    di_bp: BasisBp,
+    basis_bp: BasisBp,
+    price_cents: MoneyCents,
+    drivers: TradingDrivers,
+}
+
+impl PriceView {
+    pub fn di_bp(&self) -> BasisBp {
+        self.di_bp
+    }
+
+    pub fn basis_bp(&self) -> BasisBp {
+        self.basis_bp
+    }
+
+    pub fn price_cents(&self) -> MoneyCents {
+        self.price_cents
+    }
+
+    pub fn drivers(&self) -> TradingDrivers {
+        self.drivers
+    }
+
+    pub fn with_price(mut self, base_price: MoneyCents, pricing: &PricingCfg) -> Self {
+        self.price_cents = compute_price(base_price, self.di_bp, self.basis_bp, pricing);
+        self
     }
 }
 
-/// Creates a [`PriceView`] borrowing the underlying [`EconState`] so that
-/// pricing lookups can be performed without copying large state maps.
-pub fn price_view<'a>(state: &'a EconState, pricing: &'a PricingCfg) -> PriceView<'a> {
-    PriceView {
-        di_bp: &state.di_bp,
-        basis_bp: &state.basis_bp,
-        pricing,
+fn derive_drivers(state: &EconState, _basis_cfg: &BasisCfg) -> TradingDrivers {
+    TradingDrivers {
         pp: state.pp,
-        // Weather/route closures/stock deviation are currently sourced from the
-        // deterministic economy step, which feeds clear weather and zeroed
-        // modifiers into the basis dynamics. They are surfaced here so that
-        // trading systems can treat them as read-only drivers when richer data
-        // becomes available.
         weather: Weather::Clear,
         closed_routes: 0,
         stock_dev: 0,
+    }
+}
+
+pub fn trading_drivers(state: &EconState, rulepack: &Rulepack) -> TradingDrivers {
+    derive_drivers(state, &rulepack.basis)
+}
+
+pub fn price_view(
+    hub: HubId,
+    commodity: CommodityId,
+    state: &EconState,
+    rulepack: &Rulepack,
+) -> PriceView {
+    let di_bp = state.di_bp.get(&commodity).copied().unwrap_or(BasisBp(0));
+    let basis_bp = state
+        .basis_bp
+        .get(&(hub, commodity))
+        .copied()
+        .unwrap_or(BasisBp(0));
+
+    let drivers = trading_drivers(state, rulepack);
+
+    PriceView {
+        di_bp,
+        basis_bp,
+        price_cents: MoneyCents::ZERO,
+        drivers,
     }
 }

--- a/crates/game/src/systems/trading/tests/pricing_vm_rounding.rs
+++ b/crates/game/src/systems/trading/tests/pricing_vm_rounding.rs
@@ -1,7 +1,12 @@
 use std::collections::HashMap;
 
 use crate::systems::economy::{
-    compute_price, rulepack::PricingCfg, BasisBp, CommodityId, EconState, HubId, MoneyCents,
+    compute_price,
+    rulepack::{
+        BasisCfg, BasisWeatherCfg, DiCfg, InterestCfg, PpCfg, PricingCfg, RotCfg, Rulepack,
+        TradingCfg,
+    },
+    BasisBp, CommodityId, EconState, HubId, MoneyCents,
 };
 use crate::systems::trading::pricing_vm::price_view;
 
@@ -12,9 +17,72 @@ fn unlimited_pricing_cfg() -> PricingCfg {
     }
 }
 
+fn stub_rulepack(pricing: PricingCfg) -> Rulepack {
+    Rulepack {
+        di: DiCfg {
+            long_run_mean_bp: 0,
+            retention_bp: 0,
+            noise_sigma_bp: 0,
+            noise_clamp_bp: 0,
+            per_day_clamp_bp: 0,
+            absolute_min_bp: -10_000,
+            absolute_max_bp: 10_000,
+            overlay_decay_bp: 0,
+            overlay_min_bp: -10_000,
+            overlay_max_bp: 10_000,
+        },
+        basis: BasisCfg {
+            beta_pp_bp: 0,
+            beta_routes_bp: 0,
+            beta_stock_bp: 0,
+            noise_sigma_bp: 0,
+            noise_clamp_bp: 0,
+            per_day_clamp_bp: 0,
+            absolute_min_bp: -10_000,
+            absolute_max_bp: 10_000,
+            weather: BasisWeatherCfg {
+                clear_bp: 0,
+                rains_bp: 0,
+                fog_bp: 0,
+                windy_bp: 0,
+            },
+        },
+        interest: InterestCfg {
+            base_leg_bp: 0,
+            linear_leg_bp: 0,
+            linear_scale_cents: 1,
+            convex_leg_bp: 0,
+            convex_gamma_q16: 0,
+            per_leg_cap_bp: 0,
+        },
+        rot: RotCfg {
+            rot_floor: 0,
+            rot_ceiling: 0,
+            rot_decay_per_day: 0,
+            conversion_chunk: 1,
+            debt_per_chunk_cents: 0,
+        },
+        pp: PpCfg {
+            min_pp: 0,
+            max_pp: 100,
+            neutral_pp: 50,
+            planting_size_to_pp_bp: 0,
+            planting_max_age_days: 0,
+            decay_per_day_bp: 0,
+            pull_strength_bp: 0,
+            pull_decay_bp: 0,
+        },
+        pricing,
+        trading: TradingCfg {
+            transaction_fee_bp: 0,
+        },
+    }
+}
+
 #[test]
 fn price_view_resolves_half_cent_ties_like_compute_price() {
     let pricing = unlimited_pricing_cfg();
+    let rulepack = stub_rulepack(pricing.clone());
     let commodity = CommodityId(1);
     let hub = HubId(7);
 
@@ -24,18 +92,20 @@ fn price_view_resolves_half_cent_ties_like_compute_price() {
         ..EconState::default()
     };
 
-    let view = price_view(&state, &pricing);
+    let view =
+        price_view(hub, commodity, &state, &rulepack).with_price(MoneyCents(5), &rulepack.pricing);
 
     let base = MoneyCents(5);
-    let expected = compute_price(base, BasisBp(-500), BasisBp(-500), &pricing);
-    let quoted = view.quote(hub, commodity, base);
+    let expected = compute_price(base, BasisBp(-500), BasisBp(-500), &rulepack.pricing);
+    let quoted = view.price_cents();
     assert_eq!(quoted, expected, "ties-to-even should match compute_price");
 
     state.di_bp.insert(commodity, BasisBp(-2_000));
-    let view = price_view(&state, &pricing);
+    let view =
+        price_view(hub, commodity, &state, &rulepack).with_price(MoneyCents(2), &rulepack.pricing);
     let base = MoneyCents(2);
-    let expected = compute_price(base, BasisBp(-2_000), BasisBp(-500), &pricing);
-    let quoted = view.quote(hub, commodity, base);
+    let expected = compute_price(base, BasisBp(-2_000), BasisBp(-500), &rulepack.pricing);
+    let quoted = view.price_cents();
     assert_eq!(
         quoted, expected,
         "half-cent rounding up must match compute_price"
@@ -45,6 +115,7 @@ fn price_view_resolves_half_cent_ties_like_compute_price() {
 #[test]
 fn price_view_preserves_final_flooring() {
     let pricing = unlimited_pricing_cfg();
+    let rulepack = stub_rulepack(pricing.clone());
     let commodity = CommodityId(2);
     let hub = HubId(3);
 
@@ -54,13 +125,12 @@ fn price_view_preserves_final_flooring() {
         ..EconState::default()
     };
 
-    let view = price_view(&state, &pricing);
-
     let base = MoneyCents(1_234);
-    let expected = compute_price(base, BasisBp(3_333), BasisBp(-444), &pricing);
-    let quoted = view.quote(hub, commodity, base);
+    let view = price_view(hub, commodity, &state, &rulepack).with_price(base, &rulepack.pricing);
+    let expected = compute_price(base, BasisBp(3_333), BasisBp(-444), &rulepack.pricing);
+    let quoted = view.price_cents();
     assert_eq!(
         quoted, expected,
-        "final floor parity should match compute_price"
+        "final floor parity should match compute_price",
     );
 }


### PR DESCRIPTION
## Summary
- replace the pricing view maps with a concrete `PriceView` that carries per-quote multipliers, computed price, and `TradingDrivers`
- update the trading engine, UI, and replay harness to request a `(hub, commodity)` view and pass the priced result into trade execution
- refresh trading tests to exercise the new API while keeping rounding behaviour aligned with `compute_price`

## Testing
- cargo test trading

------
https://chatgpt.com/codex/tasks/task_e_69030b7bbe90832ebf784b0d758912b2